### PR TITLE
wrap node logo with link back home; move nodemon to dev deps

### DIFF
--- a/base.hbs
+++ b/base.hbs
@@ -105,7 +105,7 @@
   <div class="top-container container">
     <div class="row">
       <div class="column" style="text-align:center">
-        <img class="logo" src="/static/new-node.png" alt=""/>
+        <a href="/"><img class="logo" src="/static/new-node.png" alt=""/></a>
       </div>
       <div class="column">
         {{{top}}}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "handlebars": "^4.0.5",
     "marked": "^0.3.5",
     "milligram": "^1.0.3",
-    "nodemon": "^1.8.1",
     "st": "^1.1.0"
+  },
+  "devDependencies": {
+    "nodemon": "^1.8.1"
   }
 }


### PR DESCRIPTION
Addressed issue #59, brought up by @ashleygwilliams.  Wrapped node logo with anchor tag.  Also, moved nodemon dependency to devDependencies in package.json while at it.  
