### PR TITLE
Fix link to http://www.districthallboston.org/

### DIFF
--- a/events/boston.html
+++ b/events/boston.html
@@ -182,7 +182,7 @@
     <h1 id="boston">Boston</h1>
 <p><strong>August 24, 2016</strong></p>
 <ul>
-<li><strong>Location</strong> <a href="www.districthallboston.org">District Hall</a></li>
+<li><strong>Location</strong> <a href="http://www.districthallboston.org/">District Hall</a></li>
 <li><strong>Address</strong> 75 Northern Avenue Boston, MA 02210</li>
 </ul>
 <p><a class="button" href="https://www.regonline.com/Register/Checkin.aspx?EventID=1813427">Register Now!</a></p>

--- a/events/boston.md
+++ b/events/boston.md
@@ -1,7 +1,7 @@
 # Boston
 
 **August 24, 2016**
-* **Location** [District Hall](www.districthallboston.org)
+* **Location** [District Hall](http://www.districthallboston.org/)
 * **Address** 75 Northern Avenue Boston, MA 02210
 
 <a class="button" href="https://www.regonline.com/Register/Checkin.aspx?EventID=1813427">Register Now!</a>

--- a/zh-CN/events/boston.html
+++ b/zh-CN/events/boston.html
@@ -182,7 +182,7 @@
     <h1 id="boston">Boston</h1>
 <p><strong>August 24, 2016</strong></p>
 <ul>
-<li><strong>Location</strong> <a href="www.districthallboston.org">District Hall</a></li>
+<li><strong>Location</strong> <a href="http://www.districthallboston.org/">District Hall</a></li>
 <li><strong>Address</strong> 75 Northern Avenue Boston, MA 02210</li>
 </ul>
 <p><a class="button" href="https://www.regonline.com/Register/Checkin.aspx?EventID=1813427">Register Now!</a></p>


### PR DESCRIPTION
Right now the link to http://www.districthallboston.org/ does not work because the URL is treated as a relative URL.
This patch fixes the issue by using an absolute URL. 
